### PR TITLE
running c2wasm-api as non-priviledged user

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,7 @@
 FROM --platform=linux/amd64 node:17-alpine
 MAINTAINER Vaclav Barta "vaclav@equilibrium.co"
 
+RUN apk --no-cache add su-exec
 COPY clangd /usr/bin
 WORKDIR /app
 COPY c2wasm-api/clang/includes ./clang/includes
@@ -12,6 +13,8 @@ COPY wasi-sdk ./clang/wasi-sdk
 ADD compile_flags.txt /etc/clangd/compile_flags.txt
 ADD .clang-tidy /work/.clang-tidy
 RUN cp -alf ./clang/includes /work/c && cp -alf clang/wasi-sdk/share/wasi-sysroot/include /usr && mkdir -p /usr/include/clang/14.0.0 && cp -alf clang/wasi-sdk/lib/clang/14.0.0/include /usr/include/clang/14.0.0
+RUN addgroup -S appgroup && adduser -S appuser -G appgroup -h /app && chown appuser:appgroup /app
+USER appuser
 RUN yarn && yarn build
 EXPOSE $PORT
 CMD ["node", "dist/index.js"]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     ports:
       - "9000:9000"
     working_dir: /app
-    command: yarn dev
+    command: [ "/sbin/su-exec", "appuser", "yarn", "dev" ]
     volumes:
       - ../c2wasm-api/src:/app/src
     environment:


### PR DESCRIPTION
The compilation service should run as a (single) non-root user.