### PR TITLE
fix JSHooks output format

### DIFF
--- a/c2wasm-api/src/jshooks.ts
+++ b/c2wasm-api/src/jshooks.ts
@@ -99,7 +99,7 @@ function serialize_file_data(filename: string, compress: boolean) {
     .match(/0x[a-fA-F0-9]+/g)
     ?.map(hex => hex.replace('0x', ''))
     .join('') || '';
-  content = Buffer.from(hexData)
+  content = Buffer.from(hexData, 'hex')
   if (compress) {
     content = deflateSync(content);
   }


### PR DESCRIPTION
# Breaking change

This change will allow hooks-cli to process the response binary data of c hook and jshook with the same code.

## before

It was outputting data that had been converted from hex binary (i.e. character strings) to binary.

## after

Returns the binary data itself, in the same way as c hooks.