### PR TITLE
[Idea] Allows c/js compilation from the docker run command

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,9 +1,10 @@
 FROM --platform=linux/amd64 node:17-alpine
 MAINTAINER Vaclav Barta "vaclav@equilibrium.co"
 
-RUN apk --no-cache add su-exec
+RUN apk --no-cache add su-exec make
 COPY clangd /usr/bin
 WORKDIR /app
+COPY Makefile.build ./Makefile
 COPY c2wasm-api/clang/includes ./clang/includes
 COPY c2wasm-api/package.json .
 COPY c2wasm-api/yarn.lock .
@@ -17,6 +18,7 @@ COPY run.sh .
 ADD compile_flags.txt /etc/clangd/compile_flags.txt
 ADD .clang-tidy /work/.clang-tidy
 ADD .clangd /work/.clangd
+RUN mkdir -p /app/compile
 RUN cp -alf ./clang/includes /work/c && cp -alf clang/wasi-sdk/share/wasi-sysroot/include /usr && mkdir -p /usr/lib/clang/15.0.0 && cp -alf clang/wasi-sdk/lib/clang/15.0.0/include /usr/lib/clang/15.0.0
 RUN addgroup -S appgroup && adduser -S appuser -G appgroup -h /app && chown appuser:appgroup /app
 RUN yarn && yarn build

--- a/docker/Makefile.build
+++ b/docker/Makefile.build
@@ -1,0 +1,31 @@
+
+CLANG_OPTIONS = -xc -fdiagnostics-print-source-range-info -Werror=implicit-function-declaration --no-standard-libraries -nostartfiles -Wl,--allow-undefined,--no-entry,--export-all
+CLANG_INCLUDES = -I/app/clang/includes 
+
+C_FILE_PATH = /tmp/build_v93tglbrj.$/base.c
+WASM_OUTPUT_DIR = /tmp/build_v93tglbrj.wasm
+
+compile-c:
+	$(eval INPUT_FILE := $(word 2,$(MAKECMDGOALS)))
+	$(eval OUTPUT_DIR := $(word 3,$(MAKECMDGOALS)))
+	$(eval HEADER_DIR := $(word 4,$(MAKECMDGOALS)))
+	$(eval BASENAME := $(notdir $(basename $(INPUT_FILE))))
+	$(eval INPUT_PATH := ./compile/$(INPUT_FILE))
+	$(eval OUTPUT_PATH := ./compile/$(OUTPUT_DIR))
+	$(eval INCLUDES := $(if $(HEADER_DIR),-I$(HEADER_DIR),$(CLANG_INCLUDES)))
+	/app/clang/wasi-sdk/bin/clang $(CLANG_OPTIONS) $(INCLUDES) $(INPUT_PATH) -o /tmp/$(BASENAME)_unopt.wasm
+	mkdir -p $(OUTPUT_PATH)
+	wasm-opt -O3 -o $(OUTPUT_PATH)/$(BASENAME).wasm /tmp/$(BASENAME)_unopt.wasm
+	hook-cleaner $(OUTPUT_PATH)/$(BASENAME).wasm
+
+compile-js:
+	$(eval INPUT_FILE := $(word 2,$(MAKECMDGOALS)))
+	$(eval OUTPUT_DIR := $(word 3,$(MAKECMDGOALS)))
+	$(eval BASENAME := $(notdir $(basename $(INPUT_FILE))))
+	$(eval INPUT_PATH := ./compile/$(INPUT_FILE))
+	$(eval OUTPUT_PATH := ./compile/$(OUTPUT_DIR))
+	mkdir -p $(OUTPUT_PATH)
+	qjsc -c -o $(OUTPUT_PATH)/$(BASENAME).c $(INPUT_PATH)
+
+.DEFAULT:
+	@:


### PR DESCRIPTION
Allows compilation of c or js files from the `docker run` command without going through the API server.

The js file is not a so-called `bc` file, but a c file that contains the main function. (The output file of qjsc itself)


sample
- `docker run --rm -v $(pwd):/app/compile/ c2wasm-api-server make compile-c contracts-c/base.c build`
- `docker run --rm -v $(pwd):/app/compile/ c2wasm-api-server make compile-js contracts-js/base.js build`