### PR TITLE
feat: support client-provided header files in language server

### DIFF
--- a/compiler-api/package.json
+++ b/compiler-api/package.json
@@ -20,6 +20,7 @@
     "fastify-cors": "^6.0.2",
     "fastify-websocket": "^4.0.0",
     "tsc": "^2.0.3",
+    "vscode-languageserver-textdocument": "^1.0.12",
     "vscode-ws-jsonrpc": "^0.2.0",
     "ws": "^8.3.0",
     "zod": "^3.11.6"

--- a/compiler-api/src/index.ts
+++ b/compiler-api/src/index.ts
@@ -2,10 +2,8 @@ import fastify from 'fastify';
 import { readFileSync, readdirSync } from "fs";
 import fastifyCors from 'fastify-cors';
 import fastifyWebSocket from 'fastify-websocket';
-import * as ws from 'ws';
-import * as rpc from 'vscode-ws-jsonrpc';
-import * as rpcServer from 'vscode-ws-jsonrpc/lib/server';
 import { build_project as build_c_project, requestBodySchema as requestCBodySchema, RequestBody as RequestCBody } from './chooks';
+import { handleCLanguageServer } from './language-server/c';
 import { build_project as build_js_project, requestBodySchema as requestJSBodySchema, RequestBody as RequestJSBody } from './jshooks';
 
 const server = fastify();
@@ -87,39 +85,12 @@ server.get('/', async (req, reply) => {
   reply.code(200).send('ok')
 })
 
-function toSocket(webSocket: ws): rpc.IWebSocket {
-  return {
-    send: content => webSocket.send(content),
-    onMessage: cb => webSocket.onmessage = event => cb(event.data),
-    onError: cb => webSocket.onerror = event => {
-      if ('message' in event) {
-        cb((event as any).message)
-      }
-    },
-    onClose: cb => webSocket.onclose = event => cb(event.code, event.reason),
-    dispose: () => webSocket.close()
-  }
-}
-
-server.get('/language-server/c', { websocket: true }, (connection /* SocketStream */, req /* FastifyRequest */) => {
-  let localConnection = rpcServer.createServerProcess('Clangd process', 'clangd', ['--compile-commands-dir=/etc/clangd', '--limit-results=200']);
-  let socket: rpc.IWebSocket = toSocket(connection.socket);
-  let newConnection = rpcServer.createWebSocketConnection(socket);
-  rpcServer.forward(newConnection, localConnection);
-  console.log(`Forwarding new client`);
-  socket.onClose((code, reason) => {
-    console.log('Client closed', reason);
-    try {
-      localConnection.dispose();
-    } catch (err) {
-      console.log(err)
-    }
+server.get('/language-server/c', { websocket: true }, (connection, req) => {
+  handleCLanguageServer(connection, {
+    tempDir: tempDir,
+    hookHeadersDir: process.cwd() + '/clang/includes',
   });
-  // connection.socket.on('message', message => {
-  //   // message.toString() === 'hi from client'
-  //   connection.socket.send('hi from server')
-  // })
-})
+});
 
 server.get('/api/header-files', async (req, reply) => {
   const dirPath = './clang/includes';

--- a/compiler-api/src/language-server/c/index.ts
+++ b/compiler-api/src/language-server/c/index.ts
@@ -4,42 +4,11 @@ import { dirname, join } from "path";
 import * as rpc from 'vscode-ws-jsonrpc';
 import * as rpcServer from 'vscode-ws-jsonrpc/lib/server';
 import { SocketStream } from 'fastify-websocket';
+import { TextDocument } from 'vscode-languageserver-textdocument';
 
 export interface LanguageServerConfig {
   tempDir: string;
   hookHeadersDir?: string;
-}
-
-/**
- * Helper function to convert LSP Position to text offset
- */
-function positionToOffset(text: string, position: { line: number; character: number }): number {
-  const lines = text.split('\n');
-  let offset = 0;
-  for (let i = 0; i < position.line && i < lines.length; i++) {
-    offset += lines[i].length + 1; // +1 for newline character
-  }
-  return offset + Math.min(position.character, lines[position.line]?.length || 0);
-}
-
-/**
- * Helper function to apply a single change to text
- */
-function applyChange(originalText: string, change: {
-  range?: { start: { line: number; character: number }; end: { line: number; character: number } };
-  rangeLength?: number;
-  text: string;
-}): string {
-  // Full text replacement (no range specified)
-  if (!change.range) {
-    return change.text;
-  }
-
-  // Range-based replacement
-  const startOffset = positionToOffset(originalText, change.range.start);
-  const endOffset = positionToOffset(originalText, change.range.end);
-
-  return originalText.slice(0, startOffset) + change.text + originalText.slice(endOffset);
 }
 
 /**
@@ -168,11 +137,19 @@ export function handleCLanguageServer(connection: SocketStream, config: Language
               if (existsSync(filePath))
                 currentContent = readFileSync(filePath, 'utf-8');
 
-              let updatedContent = currentContent;
-              for (const change of message.params.contentChanges)
-                updatedContent = applyChange(updatedContent, change);
+              const currentDocument = TextDocument.create(
+                fileUri,
+                'c',
+                message.params.textDocument.version ?? 0,
+                currentContent
+              );
+              const updatedDocument = TextDocument.update(
+                currentDocument,
+                message.params.contentChanges,
+                message.params.textDocument.version ?? currentDocument.version + 1
+              );
 
-              writeFileSync(filePath, updatedContent);
+              writeFileSync(filePath, updatedDocument.getText());
             }
           }
 

--- a/compiler-api/src/language-server/c/index.ts
+++ b/compiler-api/src/language-server/c/index.ts
@@ -1,0 +1,291 @@
+import { mkdirSync, writeFileSync, rmSync, existsSync, readFileSync } from "fs";
+import { join } from "path";
+import * as rpc from 'vscode-ws-jsonrpc';
+import * as rpcServer from 'vscode-ws-jsonrpc/lib/server';
+import { SocketStream } from 'fastify-websocket';
+
+export interface LanguageServerConfig {
+  tempDir: string;
+  hookHeadersDir?: string;
+}
+
+/**
+ * Helper function to convert LSP Position to text offset
+ */
+function positionToOffset(text: string, position: { line: number; character: number }): number {
+  const lines = text.split('\n');
+  let offset = 0;
+  for (let i = 0; i < position.line && i < lines.length; i++) {
+    offset += lines[i].length + 1; // +1 for newline character
+  }
+  return offset + Math.min(position.character, lines[position.line]?.length || 0);
+}
+
+/**
+ * Helper function to apply a single change to text
+ */
+function applyChange(originalText: string, change: {
+  range?: { start: { line: number; character: number }; end: { line: number; character: number } };
+  rangeLength?: number;
+  text: string;
+}): string {
+  // Full text replacement (no range specified)
+  if (!change.range) {
+    return change.text;
+  }
+
+  // Range-based replacement
+  const startOffset = positionToOffset(originalText, change.range.start);
+  const endOffset = positionToOffset(originalText, change.range.end);
+
+  return originalText.slice(0, startOffset) + change.text + originalText.slice(endOffset);
+}
+
+/**
+ * Handle WebSocket connection for C language server
+ */
+export function handleCLanguageServer(connection: SocketStream, config: LanguageServerConfig): void {
+  // create a temporary directory for the workspace
+  const workspaceDir = config.tempDir + '/language-server' + '/ls_' + Math.random().toString(36).slice(2);
+
+  mkdirSync(workspaceDir, { recursive: true });
+
+  const hookHeadersDir = config.hookHeadersDir || '/app/clang/includes';
+  const compileFlagsContent = [
+    '-xc',
+    '-isystem/usr/lib/clang/15.0.0/include',
+    '-Wno-pointer-to-int-cast',
+    '-Wno-int-conversion',
+    '-Werror=implicit-function-declaration',
+    `-I${workspaceDir}`,
+    `-I${hookHeadersDir}`,
+  ].join('\n') + '\n';
+  writeFileSync(join(workspaceDir, 'compile_flags.txt'), compileFlagsContent);
+
+  const clangdConfigContent = `Security:
+  AccessibleDirectories: [ "${workspaceDir}", "/usr/include", "/usr/lib/clang", "${hookHeadersDir}" ]
+`;
+  writeFileSync(join(workspaceDir, '.clangd'), clangdConfigContent);
+
+  // run clangd with the following arguments
+  let localConnection = rpcServer.createServerProcess('Clangd process', 'clangd', [
+    `--compile-commands-dir=${workspaceDir}`,
+    `--limit-results=200`,
+    `--background-index=false`,
+    `--log=error`
+  ], {
+    cwd: workspaceDir
+  });
+
+  // intercept messages from the client and process them
+  let initialized = false;
+  let messageHandler: ((data: any) => void) | null = null;
+  const openDocuments = new Set<string>(); // track opened documents
+
+  /**
+   * Helper function to ensure a file is opened in clangd
+   */
+  const ensureDocumentOpen = (uri: string, text?: string): string => {
+    const fileName = uri.replace(/^file:\/\//, '');
+    const filePath = join(workspaceDir, fileName);
+    const fileUri = `file://${filePath}`;
+
+    if (!openDocuments.has(fileUri)) {
+      // console.log('Auto-opening document:', fileUri);
+
+      // create the directory if it doesn't exist
+      const dir = join(workspaceDir, fileName.split('/').slice(0, -1).join('/'));
+      if (dir !== workspaceDir) {
+        mkdirSync(dir, { recursive: true });
+      }
+
+      // read file content if not provided
+      let fileContent = text;
+      if (!fileContent && existsSync(filePath)) {
+        fileContent = readFileSync(filePath, 'utf-8');
+      } else if (!fileContent) {
+        fileContent = ''; // empty file if it doesn't exist
+      }
+
+      // write the file to the temporary directory
+      writeFileSync(filePath, fileContent);
+
+      // send textDocument/didOpen to clangd
+      if (messageHandler) {
+        const didOpenMessage = {
+          jsonrpc: '2.0',
+          method: 'textDocument/didOpen',
+          params: {
+            textDocument: {
+              uri: fileUri,
+              languageId: fileName.endsWith('.h') ? 'c' : 'c',
+              version: 1,
+              text: fileContent
+            }
+          }
+        };
+        // console.log('Sending didOpen for:', fileUri);
+        messageHandler(JSON.stringify(didOpenMessage));
+      }
+
+      openDocuments.add(fileUri);
+    }
+
+    return fileUri;
+  };
+
+  // create a custom IWebSocket that intercepts messages
+  const interceptedSocket: rpc.IWebSocket = {
+    send: (content) => connection.socket.send(content),
+    onMessage: (cb) => {
+      // console.log('onMessage callback registered');
+      messageHandler = cb;
+      connection.socket.onmessage = (event) => {
+        const data = event.data;
+        // console.log('Raw message received:', data.toString().substring(0, 100));
+
+        try {
+          const message = JSON.parse(data.toString());
+          // console.log('Parsed message method:', message.method);
+
+          // set the workspace folder
+          if (message.method === 'initialize' && !initialized) {
+            initialized = true;
+            // console.log('Initializing workspace:', workspaceDir);
+            // set the workspace folder
+            if (!message.params) {
+              message.params = {};
+            }
+            if (!message.params.workspaceFolders) {
+              message.params.workspaceFolders = [{
+                uri: `file://${workspaceDir}`,
+                name: 'workspace'
+              }];
+            }
+          }
+
+          // handle textDocument/didOpen messages and write the file to the temporary directory
+          if (message.method === 'textDocument/didOpen' && message.params?.textDocument) {
+            const uri = message.params.textDocument.uri;
+            const text = message.params.textDocument.text;
+
+            // console.log('textDocument/didOpen received, URI:', uri);
+
+            // extract the file name from the URI (example: file://file.c -> file.c)
+            const fileName = uri.replace(/^file:\/\//, '');
+            const filePath = join(workspaceDir, fileName);
+
+            // create the directory if it doesn't exist
+            const dir = join(workspaceDir, fileName.split('/').slice(0, -1).join('/'));
+            if (dir !== workspaceDir) {
+              mkdirSync(dir, { recursive: true });
+            }
+
+            // write the file to the temporary directory
+            // console.log('Writing file to ', filePath);
+            writeFileSync(filePath, text);
+
+            // convert the URI to file:// URI
+            const fileUri = `file://${filePath}`;
+            message.params.textDocument.uri = fileUri;
+            openDocuments.add(fileUri);
+          }
+
+          // handle textDocument/didChange messages and update the file in the temporary directory
+          if (message.method === 'textDocument/didChange' && message.params?.textDocument) {
+            const uri = message.params.textDocument.uri;
+
+            // console.log('textDocument/didChange received, URI:', uri);
+
+            // ensure the document is open
+            const fileUri = ensureDocumentOpen(uri);
+
+            const fileName = uri.replace(/^file:\/\//, '');
+            const filePath = join(workspaceDir, fileName);
+
+            // apply the changes to the file
+            if (message.params.contentChanges && message.params.contentChanges.length > 0) {
+              // console.log('Content changes:', message.params.contentChanges.length);
+
+              // read current file content
+              let currentContent = '';
+              if (existsSync(filePath)) {
+                currentContent = readFileSync(filePath, 'utf-8');
+              }
+
+              // apply all changes sequentially
+              let updatedContent = currentContent;
+              for (const change of message.params.contentChanges) {
+                // console.log('Applying change:', change.range ? `range ${change.range.start.line}:${change.range.start.character}-${change.range.end.line}:${change.range.end.character}` : 'full text');
+                updatedContent = applyChange(updatedContent, change);
+              }
+
+              // write the updated content
+              // console.log('Updating file:', filePath);
+              // console.log('updatedContent: ', updatedContent);
+              writeFileSync(filePath, updatedContent);
+            }
+
+            // convert the URI to file:// URI
+            message.params.textDocument.uri = fileUri;
+          }
+
+          // handle other textDocument requests (hover, completion, etc.) - ensure document is open
+          if (message.method && message.method.startsWith('textDocument/') &&
+              message.method !== 'textDocument/didOpen' &&
+              message.method !== 'textDocument/didChange' &&
+              message.method !== 'textDocument/didClose' &&
+              message.params?.textDocument?.uri) {
+            const uri = message.params.textDocument.uri;
+            // console.log(`Ensuring document is open for ${message.method}:`, uri);
+            const fileUri = ensureDocumentOpen(uri);
+            message.params.textDocument.uri = fileUri;
+          }
+
+          // send the converted message to clangd
+          if (messageHandler) {
+            messageHandler(JSON.stringify(message));
+          }
+        } catch (err) {
+          console.error('Error processing message:', err);
+          // if there is a JSON parsing error, forward the original data
+          if (messageHandler) {
+            messageHandler(data);
+          }
+        }
+      };
+    },
+    onError: (cb) => {
+      connection.socket.onerror = (event) => {
+        if ('message' in event) {
+          cb((event as any).message);
+        }
+      };
+    },
+    onClose: (cb) => {
+      connection.socket.onclose = (event) => {
+        cb(event.code, event.reason);
+      };
+    },
+    dispose: () => {
+      connection.socket.close();
+    }
+  };
+
+  let newConnection = rpcServer.createWebSocketConnection(interceptedSocket);
+
+  rpcServer.forward(newConnection, localConnection);
+  // console.log(`Forwarding new client, workspace: ${workspaceDir}`);
+
+  interceptedSocket.onClose((code, reason) => {
+    // console.log('Client closed', code, reason);
+    try {
+      localConnection.dispose();
+      // delete the temporary directory
+      rmSync(workspaceDir, { recursive: true, force: true });
+      // console.log('Cleaned up workspace directory:', workspaceDir);
+    } catch (err) {
+      console.error('Error cleaning up:', err);
+    }
+  });
+}

--- a/compiler-api/src/language-server/c/index.ts
+++ b/compiler-api/src/language-server/c/index.ts
@@ -95,6 +95,10 @@ export function handleCLanguageServer(connection: SocketStream, config: Language
       if (!fileContent && existsSync(filePath)) {
         fileContent = readFileSync(filePath, 'utf-8');
       } else if (!fileContent) {
+        // A well-behaved client sends didOpen (with full text) before any other
+        // request for a document, so bootstrapping from empty here means the
+        // client skipped that step and range-based edits may desync.
+        console.warn('Document opened without content, starting empty:', fileUri);
         fileContent = ''; // empty file if it doesn't exist
       }
 
@@ -109,7 +113,7 @@ export function handleCLanguageServer(connection: SocketStream, config: Language
           params: {
             textDocument: {
               uri: fileUri,
-              languageId: fileName.endsWith('.h') ? 'c' : 'c',
+              languageId: 'c',
               version: 1,
               text: fileContent
             }
@@ -127,11 +131,16 @@ export function handleCLanguageServer(connection: SocketStream, config: Language
 
   // create a custom IWebSocket that intercepts messages
   const interceptedSocket: rpc.IWebSocket = {
-    send: (content) => connection.socket.send(content),
+    send: (content) => {
+      // clangd replies with URIs under the temp workspace; translate them back
+      // to the URIs the client opened so it can match its own documents.
+      const outgoing = content.toString().split(`file://${workspaceDir}`).join('file://');
+      connection.socket.send(outgoing);
+    },
     onMessage: (cb) => {
       // console.log('onMessage callback registered');
       messageHandler = cb;
-      connection.socket.onmessage = (event) => {
+      connection.socket.onmessage = (event: any) => {
         const data = event.data;
         // console.log('Raw message received:', data.toString().substring(0, 100));
 
@@ -221,6 +230,22 @@ export function handleCLanguageServer(connection: SocketStream, config: Language
             message.params.textDocument.uri = fileUri;
           }
 
+          // handle textDocument/didClose messages and stop tracking the document
+          if (message.method === 'textDocument/didClose' && message.params?.textDocument?.uri) {
+            const uri = message.params.textDocument.uri;
+
+            // console.log('textDocument/didClose received, URI:', uri);
+
+            // extract the file name from the URI (example: file://file.c -> file.c)
+            const fileName = uri.replace(/^file:\/\//, '');
+            const filePath = join(workspaceDir, fileName);
+
+            // convert the URI to file:// URI
+            const fileUri = `file://${filePath}`;
+            message.params.textDocument.uri = fileUri;
+            openDocuments.delete(fileUri);
+          }
+
           // handle other textDocument requests (hover, completion, etc.) - ensure document is open
           if (message.method && message.method.startsWith('textDocument/') &&
               message.method !== 'textDocument/didOpen' &&
@@ -247,14 +272,14 @@ export function handleCLanguageServer(connection: SocketStream, config: Language
       };
     },
     onError: (cb) => {
-      connection.socket.onerror = (event) => {
+      connection.socket.onerror = (event: any) => {
         if ('message' in event) {
           cb((event as any).message);
         }
       };
     },
     onClose: (cb) => {
-      connection.socket.onclose = (event) => {
+      connection.socket.onclose = (event: any) => {
         cb(event.code, event.reason);
       };
     },
@@ -294,7 +319,7 @@ export function handleCLanguageServer(connection: SocketStream, config: Language
   serverProcess.stdin?.on('error', (err) => dispose(`clangd stdin error: ${err}`));
   serverProcess.stdout?.on('error', (err) => dispose(`clangd stdout error: ${err}`));
   serverProcess.stderr?.on('data', (data) => console.error(`clangd: ${data}`));
-  connection.socket.on('error', (err) => dispose(`websocket error: ${err}`));
+  connection.socket.on('error', (err: Error) => dispose(`websocket error: ${err}`));
 
   try {
     rpcServer.forward(newConnection, localConnection);

--- a/compiler-api/src/language-server/c/index.ts
+++ b/compiler-api/src/language-server/c/index.ts
@@ -36,8 +36,10 @@ export function handleCLanguageServer(connection: SocketStream, config: Language
   AccessibleDirectories: [ "${workspaceDir}", "/usr/include", "/usr/lib/clang", "${hookHeadersDir}" ]
 `;
   writeFileSync(join(workspaceDir, '.clangd'), clangdConfigContent);
+  
+  type MessageHandler = Parameters<rpc.IWebSocket['onMessage']>[0];
 
-  const sendDidOpen = (send: (data: any) => void, uri: string, text: string) => {
+  const sendDidOpen = (send: MessageHandler, uri: string, text: string) => {
     send(JSON.stringify({
       jsonrpc: '2.0',
       method: 'textDocument/didOpen',
@@ -55,7 +57,7 @@ export function handleCLanguageServer(connection: SocketStream, config: Language
 
   const openDocuments = new Set<string>();
 
-  const ensureDocumentOpen = (send: (data: any) => void, uri: string): string => {
+  const ensureDocumentOpen = (send: MessageHandler, uri: string): string => {
     const { filePath, fileUri } = toWorkspaceDocument(uri);
 
     if (!openDocuments.has(fileUri)) {
@@ -89,7 +91,7 @@ export function handleCLanguageServer(connection: SocketStream, config: Language
       connection.socket.send(outgoing);
     },
     onMessage: (messageHandler) => {
-      connection.socket.onmessage = (event: any) => {
+      connection.socket.onmessage = (event) => {
         const data = event.data;
 
         try {
@@ -172,14 +174,14 @@ export function handleCLanguageServer(connection: SocketStream, config: Language
       };
     },
     onError: (errorHandler) => {
-      connection.socket.onerror = (event: any) => {
+      connection.socket.onerror = (event) => {
         if ('message' in event) {
-          errorHandler((event as any).message);
+          errorHandler(event.message);
         }
       };
     },
     onClose: (closeHandler) => {
-      connection.socket.onclose = (event: any) => {
+      connection.socket.onclose = (event) => {
         closeHandler(event.code, event.reason);
       };
     },

--- a/compiler-api/src/language-server/c/index.ts
+++ b/compiler-api/src/language-server/c/index.ts
@@ -1,6 +1,6 @@
 import { mkdirSync, writeFileSync, rmSync, existsSync, readFileSync } from "fs";
 import { spawn } from 'child_process';
-import { join } from "path";
+import { dirname, join } from "path";
 import * as rpc from 'vscode-ws-jsonrpc';
 import * as rpcServer from 'vscode-ws-jsonrpc/lib/server';
 import { SocketStream } from 'fastify-websocket';
@@ -68,60 +68,42 @@ export function handleCLanguageServer(connection: SocketStream, config: Language
 `;
   writeFileSync(join(workspaceDir, '.clangd'), clangdConfigContent);
 
-  // intercept messages from the client and process them
-  let initialized = false;
-  let messageHandler: ((data: any) => void) | null = null;
-  const openDocuments = new Set<string>(); // track opened documents
+  const sendDidOpen = (send: (data: any) => void, uri: string, text: string) => {
+    send(JSON.stringify({
+      jsonrpc: '2.0',
+      method: 'textDocument/didOpen',
+      params: {
+        textDocument: { uri, languageId: 'c', version: 1, text }
+      }
+    }));
+  };
 
-  /**
-   * Helper function to ensure a file is opened in clangd
-   */
-  const ensureDocumentOpen = (uri: string, text?: string): string => {
+  const toWorkspaceDocument = (uri: string): { filePath: string; fileUri: string } => {
     const fileName = uri.replace(/^file:\/\//, '');
     const filePath = join(workspaceDir, fileName);
-    const fileUri = `file://${filePath}`;
+    return { filePath, fileUri: `file://${filePath}` };
+  };
+
+  const openDocuments = new Set<string>();
+
+  const ensureDocumentOpen = (send: (data: any) => void, uri: string): string => {
+    const { filePath, fileUri } = toWorkspaceDocument(uri);
 
     if (!openDocuments.has(fileUri)) {
-      // console.log('Auto-opening document:', fileUri);
+      mkdirSync(dirname(filePath), { recursive: true });
 
-      // create the directory if it doesn't exist
-      const dir = join(workspaceDir, fileName.split('/').slice(0, -1).join('/'));
-      if (dir !== workspaceDir) {
-        mkdirSync(dir, { recursive: true });
-      }
-
-      // read file content if not provided
-      let fileContent = text;
-      if (!fileContent && existsSync(filePath)) {
+      let fileContent = '';
+      if (existsSync(filePath)) {
         fileContent = readFileSync(filePath, 'utf-8');
-      } else if (!fileContent) {
+      } else {
         // A well-behaved client sends didOpen (with full text) before any other
         // request for a document, so bootstrapping from empty here means the
         // client skipped that step and range-based edits may desync.
         console.warn('Document opened without content, starting empty:', fileUri);
-        fileContent = ''; // empty file if it doesn't exist
       }
 
-      // write the file to the temporary directory
       writeFileSync(filePath, fileContent);
-
-      // send textDocument/didOpen to clangd
-      if (messageHandler) {
-        const didOpenMessage = {
-          jsonrpc: '2.0',
-          method: 'textDocument/didOpen',
-          params: {
-            textDocument: {
-              uri: fileUri,
-              languageId: 'c',
-              version: 1,
-              text: fileContent
-            }
-          }
-        };
-        // console.log('Sending didOpen for:', fileUri);
-        messageHandler(JSON.stringify(didOpenMessage));
-      }
+      sendDidOpen(send, fileUri, fileContent);
 
       openDocuments.add(fileUri);
     }
@@ -137,22 +119,16 @@ export function handleCLanguageServer(connection: SocketStream, config: Language
       const outgoing = content.toString().split(`file://${workspaceDir}`).join('file://');
       connection.socket.send(outgoing);
     },
-    onMessage: (cb) => {
-      // console.log('onMessage callback registered');
-      messageHandler = cb;
+    onMessage: (messageHandler) => {
       connection.socket.onmessage = (event: any) => {
         const data = event.data;
-        // console.log('Raw message received:', data.toString().substring(0, 100));
 
         try {
           const message = JSON.parse(data.toString());
-          // console.log('Parsed message method:', message.method);
+          const method = message.method;
 
-          // set the workspace folder
-          if (message.method === 'initialize' && !initialized) {
-            initialized = true;
-            // console.log('Initializing workspace:', workspaceDir);
-            // set the workspace folder
+          if (method === 'initialize') {
+            // Point clangd at the temporary workspace used for this session.
             if (!message.params) {
               message.params = {};
             }
@@ -164,123 +140,70 @@ export function handleCLanguageServer(connection: SocketStream, config: Language
             }
           }
 
-          // handle textDocument/didOpen messages and write the file to the temporary directory
-          if (message.method === 'textDocument/didOpen' && message.params?.textDocument) {
-            const uri = message.params.textDocument.uri;
-            const text = message.params.textDocument.text;
+          const uri = message.params.textDocument.uri;
+          const { filePath, fileUri } = toWorkspaceDocument(uri);
 
-            // console.log('textDocument/didOpen received, URI:', uri);
+          if (method === 'textDocument/didOpen' && message.params?.textDocument) {
+            // Mirror the opened client document into the temporary workspace.            
 
-            // extract the file name from the URI (example: file://file.c -> file.c)
-            const fileName = uri.replace(/^file:\/\//, '');
-            const filePath = join(workspaceDir, fileName);
+            mkdirSync(dirname(filePath), { recursive: true });
+            writeFileSync(filePath, message.params.textDocument.text);
 
-            // create the directory if it doesn't exist
-            const dir = join(workspaceDir, fileName.split('/').slice(0, -1).join('/'));
-            if (dir !== workspaceDir) {
-              mkdirSync(dir, { recursive: true });
-            }
-
-            // write the file to the temporary directory
-            // console.log('Writing file to ', filePath);
-            writeFileSync(filePath, text);
-
-            // convert the URI to file:// URI
-            const fileUri = `file://${filePath}`;
-            message.params.textDocument.uri = fileUri;
             openDocuments.add(fileUri);
           }
 
-          // handle textDocument/didChange messages and update the file in the temporary directory
-          if (message.method === 'textDocument/didChange' && message.params?.textDocument) {
-            const uri = message.params.textDocument.uri;
+          if (method === 'textDocument/didClose' && message.params?.textDocument?.uri) {
+            // Stop tracking the mirrored workspace document after the client closes it.
 
-            // console.log('textDocument/didChange received, URI:', uri);
-
-            // ensure the document is open
-            const fileUri = ensureDocumentOpen(uri);
-
-            const fileName = uri.replace(/^file:\/\//, '');
-            const filePath = join(workspaceDir, fileName);
-
-            // apply the changes to the file
-            if (message.params.contentChanges && message.params.contentChanges.length > 0) {
-              // console.log('Content changes:', message.params.contentChanges.length);
-
-              // read current file content
-              let currentContent = '';
-              if (existsSync(filePath)) {
-                currentContent = readFileSync(filePath, 'utf-8');
-              }
-
-              // apply all changes sequentially
-              let updatedContent = currentContent;
-              for (const change of message.params.contentChanges) {
-                // console.log('Applying change:', change.range ? `range ${change.range.start.line}:${change.range.start.character}-${change.range.end.line}:${change.range.end.character}` : 'full text');
-                updatedContent = applyChange(updatedContent, change);
-              }
-
-              // write the updated content
-              // console.log('Updating file:', filePath);
-              // console.log('updatedContent: ', updatedContent);
-              writeFileSync(filePath, updatedContent);
-            }
-
-            // convert the URI to file:// URI
-            message.params.textDocument.uri = fileUri;
-          }
-
-          // handle textDocument/didClose messages and stop tracking the document
-          if (message.method === 'textDocument/didClose' && message.params?.textDocument?.uri) {
-            const uri = message.params.textDocument.uri;
-
-            // console.log('textDocument/didClose received, URI:', uri);
-
-            // extract the file name from the URI (example: file://file.c -> file.c)
-            const fileName = uri.replace(/^file:\/\//, '');
-            const filePath = join(workspaceDir, fileName);
-
-            // convert the URI to file:// URI
-            const fileUri = `file://${filePath}`;
-            message.params.textDocument.uri = fileUri;
             openDocuments.delete(fileUri);
           }
 
-          // handle other textDocument requests (hover, completion, etc.) - ensure document is open
-          if (message.method && message.method.startsWith('textDocument/') &&
-              message.method !== 'textDocument/didOpen' &&
-              message.method !== 'textDocument/didChange' &&
-              message.method !== 'textDocument/didClose' &&
-              message.params?.textDocument?.uri) {
-            const uri = message.params.textDocument.uri;
-            // console.log(`Ensuring document is open for ${message.method}:`, uri);
-            const fileUri = ensureDocumentOpen(uri);
-            message.params.textDocument.uri = fileUri;
+          if (method === 'textDocument/didChange' && message.params?.textDocument) {
+            // Apply incremental client edits to the mirrored workspace file.
+
+            ensureDocumentOpen(messageHandler, uri);
+
+            if (message.params.contentChanges && message.params.contentChanges.length > 0) {
+              let currentContent = '';
+              if (existsSync(filePath))
+                currentContent = readFileSync(filePath, 'utf-8');
+
+              let updatedContent = currentContent;
+              for (const change of message.params.contentChanges)
+                updatedContent = applyChange(updatedContent, change);
+
+              writeFileSync(filePath, updatedContent);
+            }
           }
 
-          // send the converted message to clangd
-          if (messageHandler) {
-            messageHandler(JSON.stringify(message));
+          if (method && method.startsWith('textDocument/') &&
+              method !== 'textDocument/didOpen' &&
+              method !== 'textDocument/didChange' &&
+              method !== 'textDocument/didClose' &&
+              message.params?.textDocument?.uri) {
+            // Ensure clangd has an opened workspace document before document requests.
+            ensureDocumentOpen(messageHandler, uri);
           }
+          
+          message.params.textDocument.uri = fileUri;
+
+          messageHandler(JSON.stringify(message));
         } catch (err) {
           console.error('Error processing message:', err);
-          // if there is a JSON parsing error, forward the original data
-          if (messageHandler) {
-            messageHandler(data);
-          }
+          messageHandler(data);
         }
       };
     },
-    onError: (cb) => {
+    onError: (errorHandler) => {
       connection.socket.onerror = (event: any) => {
         if ('message' in event) {
-          cb((event as any).message);
+          errorHandler((event as any).message);
         }
       };
     },
-    onClose: (cb) => {
+    onClose: (closeHandler) => {
       connection.socket.onclose = (event: any) => {
-        cb(event.code, event.reason);
+        closeHandler(event.code, event.reason);
       };
     },
     dispose: () => {
@@ -301,15 +224,13 @@ export function handleCLanguageServer(connection: SocketStream, config: Language
     cwd: workspaceDir
   });
 
-  const localConnection = rpcServer.createProcessStreamConnection(serverProcess);
-  const newConnection = rpcServer.createWebSocketConnection(interceptedSocket);
-
+  let localConnection: rpcServer.IConnection | null = null;
   let disposed = false;
   const dispose = (reason: string) => {
     if (disposed) return;
     disposed = true;
     console.log('Tearing down language-server session:', reason);
-    try { localConnection.dispose(); } catch (err) { console.error('Error disposing clangd connection:', err); }
+    try { localConnection?.dispose(); } catch (err) { console.error('Error disposing clangd connection:', err); }
     try { serverProcess.kill(); } catch (err) { console.error('Error killing clangd:', err); }
     try { rmSync(workspaceDir, { recursive: true, force: true }); } catch (err) { console.error('Error cleaning up workspace directory:', err); }
   };
@@ -322,6 +243,8 @@ export function handleCLanguageServer(connection: SocketStream, config: Language
   connection.socket.on('error', (err: Error) => dispose(`websocket error: ${err}`));
 
   try {
+    localConnection = rpcServer.createProcessStreamConnection(serverProcess);
+    const newConnection = rpcServer.createWebSocketConnection(interceptedSocket);
     rpcServer.forward(newConnection, localConnection);
     console.log(`Forwarding new client, workspace: ${workspaceDir}`);
   } catch (err) {

--- a/compiler-api/yarn.lock
+++ b/compiler-api/yarn.lock
@@ -760,6 +760,11 @@ vscode-jsonrpc@^5.0.0:
   resolved "https://registry.yarnpkg.com/vscode-jsonrpc/-/vscode-jsonrpc-5.0.1.tgz#9bab9c330d89f43fc8c1e8702b5c36e058a01794"
   integrity sha512-JvONPptw3GAQGXlVV2utDcHx0BiY34FupW/kI6mZ5x06ER5DdPG/tXWMVHjTNULF5uKPOUUD0SaXg5QaubJL0A==
 
+vscode-languageserver-textdocument@^1.0.12:
+  version "1.0.12"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz#457ee04271ab38998a093c68c2342f53f6e4a631"
+  integrity sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==
+
 vscode-ws-jsonrpc@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/vscode-ws-jsonrpc/-/vscode-ws-jsonrpc-0.2.0.tgz#5e9c26e10da54a1a235da7d59e74508bbcb8edd9"

--- a/docker/.clangd
+++ b/docker/.clangd
@@ -1,3 +1,3 @@
 Security:
-  AccessibleDirectories: [ "/work/c", "/usr/include", "/usr/lib/clang" ]
+  AccessibleDirectories: [ "/work/c", "/usr/include", "/usr/lib/clang", "/tmp", "/app/clang/includes" ]
 


### PR DESCRIPTION
Each WebSocket connection now gets an isolated workspace under /tmp with dynamically generated compile_flags.txt and .clangd config, allowing clangd to resolve #include directives for both client-sent .h files and default hook headers.

- Add per-connection workspace with LSP message interception
- Generate compile_flags.txt with -I paths for workspace and hook headers
- Generate .clangd config with AccessibleDirectories per workspace
- Suppress verbose LSP trace logs with --log=error
- Update docker/.clangd to allow /tmp and /app/clang/includes access